### PR TITLE
Add Codex onboarding docs and adjust automation scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md — OpenAI Codex Playbook
+
+This guide keeps OpenAI Codex (and other code-focused assistants) productive in this repository. Its scope is the entire project unless a subdirectory defines a more specific guide later on.
+
+## 1. Environment quick-start
+
+- **Node.js:** 20.x LTS (the project is tested with v20.19.4).
+- **Install dependencies:** `npm install`.
+- **Single command quality gate:** `npm run check` (runs type checking, linting, format verification, and unit tests).
+- **Dev server:** `npm run dev` (avoid leaving it running after the check you need).
+
+## 2. Core workflows
+
+1. Read the relevant files before editing—components live in `app/` for routes and `components/` for shared UI.
+2. Prefer server components in the App Router unless browser-only APIs are required; mark client components with `"use client"` at the top.
+3. Share logic through utilities in `lib/` and types in `types/`.
+4. Keep data sources in `data/` or `lib/projects.ts`; avoid hardcoding copies in components.
+5. Update or add tests under `test/` when you introduce new behaviours.
+
+## 3. Style guidelines
+
+- TypeScript with `strict` settings—annotate function signatures and avoid `any`.
+- Use Tailwind CSS utility classes; prefer extracting small components instead of large anonymous JSX blocks.
+- Reach for `clsx` when you need conditional class names.
+- Follow existing naming conventions (`PascalCase` for components, `camelCase` for helpers).
+- Keep files focused; split out modules once they exceed ~200 lines or mix concerns.
+
+## 4. Testing & validation
+
+- `npm run check` ⇒ full pre-merge validation (type-check, lint, format:check, vitest run).
+- `npm run test:run` ⇒ unit tests only (Vitest, headless).
+- `npm run test:e2e` ⇒ Playwright end-to-end suite (slower, optional unless a change affects flows).
+- `npm run lint` and `npm run format:check` are available when you want targeted feedback.
+
+Always run the relevant commands after changes. When a command fails, inspect the report and fix the code—do not rerun blindly.
+
+## 5. Useful references
+
+- `next.config.ts` and `middleware.ts` hold runtime configuration and edge logic.
+- `tailwind.config.js` and `postcss.config.mjs` control styling.
+- `vitest.config.ts` and `playwright.config.ts` define test environments.
+- Assets live under `public/`, while reusable hooks sit in `hooks/`.
+
+## 6. Productivity tips for agents
+
+- Prefer `rg` (ripgrep) and `fd` for file/contents search; they are faster than `grep`/`find`.
+- Batch edits when possible to reduce context usage.
+- Do not leave long-running processes (dev servers, Playwright UI) unattended—start, inspect, then stop.
+- Keep commit messages focused on the behaviour or configuration changes you introduce.
+
+Happy shipping!

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ npm start
 npm run validate
 ```
 
+## Working with AI coding assistants
+
+- For an agent-focused overview (including OpenAI Codex tips), read [`AGENTS.md`](./AGENTS.md).
+- Use `npm run check` for a single command that runs the required quality gates (type checking, lint, formatting verification, and unit tests).
+- Prefer `rg` (ripgrep) or `npm run lint`/`npm run test:run` for fast feedback loops during iterative work.
+
 ## Project Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
@@ -21,6 +22,7 @@
     "test:e2e:headed": "playwright test --headed",
     "test:all": "npm run test:run && npm run test:e2e",
     "validate": "npm run type-check && npm run lint && npm run format:check && npm run test:run",
+    "check": "npm run validate",
     "analyze": "ANALYZE=true next build",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary
- add a root `AGENTS.md` playbook so OpenAI Codex has project-specific onboarding guidance
- document the new workflow for AI assistants in the README and highlight the consolidated quality gate
- tweak the package scripts so `npm test` runs in non-watch mode and add an alias `npm run check`

## Testing
- npm run check *(fails: existing Prettier formatting warnings in untouched files)*
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cda51792e4832aa4ac1aad7b23f6bb