### PR TITLE
feat: auto create Codex tasks from GitHub issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,25 @@ Create `.env.local` for local development:
 # Add your email service API keys here
 MAILCHIMP_API_KEY=
 MAILCHIMP_LIST_ID=
+
+# Codex task automation
+GITHUB_WEBHOOK_SECRET=
+CODEX_API_URL=
+CODEX_API_KEY=
+# Optional: pin tasks to a specific Codex project
+CODEX_PROJECT_ID=
 ```
+
+### GitHub Webhook Automation
+
+Codex can now create follow-up tasks automatically whenever a GitHub issue is opened or reopened.
+
+1. Configure the environment variables above.
+2. Add a GitHub webhook that points to `/api/webhooks/github`.
+   - **Event type**: Issues
+   - **Content type**: `application/json`
+   - **Secret**: Matches `GITHUB_WEBHOOK_SECRET`
+3. Codex will create a task using the issue title, body, labels, and metadata.
 
 ## Featured Projects
 

--- a/app/api/webhooks/github/route.ts
+++ b/app/api/webhooks/github/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+import { createCodexTaskFromIssue } from '@/lib/codex'
+import { env } from '@/lib/env'
+import type { GitHubIssueEvent } from '@/types/github'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+function verifyGitHubSignature(signature: string | null, payload: string, secret: string) {
+  if (!signature) {
+    return false
+  }
+
+  const hmac = createHmac('sha256', secret)
+  const digest = `sha256=${hmac.update(payload).digest('hex')}`
+
+  const signatureBuffer = Buffer.from(signature)
+  const digestBuffer = Buffer.from(digest)
+
+  if (signatureBuffer.length !== digestBuffer.length) {
+    return false
+  }
+
+  return timingSafeEqual(signatureBuffer, digestBuffer)
+}
+
+export async function POST(request: NextRequest) {
+  const githubSecret = env.server.githubWebhookSecret
+  if (!githubSecret) {
+    console.error('GitHub webhook secret is not configured')
+    return NextResponse.json(
+      { error: 'Server misconfiguration: missing GitHub webhook secret' },
+      { status: 500 }
+    )
+  }
+
+  const signature = request.headers.get('x-hub-signature-256')
+  const event = request.headers.get('x-github-event')
+
+  const rawBody = await request.text()
+
+  if (!verifyGitHubSignature(signature, rawBody, githubSecret)) {
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 })
+  }
+
+  if (!event) {
+    return NextResponse.json({ error: 'Missing X-GitHub-Event header' }, { status: 400 })
+  }
+
+  let payload: GitHubIssueEvent
+  try {
+    payload = JSON.parse(rawBody) as GitHubIssueEvent
+  } catch (error) {
+    console.error('Failed to parse GitHub webhook payload', error)
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 })
+  }
+
+  if (event !== 'issues') {
+    return NextResponse.json({ message: `Ignored event type: ${event}` }, { status: 200 })
+  }
+
+  if (!payload.issue || !payload.repository) {
+    return NextResponse.json({ error: 'Malformed issues payload' }, { status: 400 })
+  }
+
+  const actionableActions = new Set(['opened', 'reopened'])
+
+  if (!payload.action || !actionableActions.has(payload.action)) {
+    return NextResponse.json(
+      { message: `Ignored issues action: ${payload.action ?? 'unknown'}` },
+      { status: 200 }
+    )
+  }
+
+  try {
+    const result = await createCodexTaskFromIssue(payload.issue, payload.repository)
+
+    return NextResponse.json({ message: 'Codex task created', taskId: result.id }, { status: 200 })
+  } catch (error) {
+    console.error('Failed to create Codex task from issue', error)
+    return NextResponse.json({ error: 'Failed to create Codex task' }, { status: 500 })
+  }
+}

--- a/lib/codex.ts
+++ b/lib/codex.ts
@@ -1,0 +1,126 @@
+import { env } from '@/lib/env'
+import type { GitHubIssue, GitHubRepository } from '@/types/github'
+
+export interface CodexTaskMetadata {
+  source: 'github'
+  repository: string
+  issueNumber: number
+  issueUrl: string
+  labels: string[]
+}
+
+export interface CodexTaskPayload {
+  title: string
+  description: string
+  metadata: CodexTaskMetadata
+  projectId?: string
+}
+
+export interface CodexTaskResponse {
+  id: string
+  url?: string
+  status?: string
+}
+
+const DEFAULT_EMPTY_BODY_MESSAGE = '_No issue description provided._'
+
+function normalizeCodexBaseUrl(baseUrl: string) {
+  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+}
+
+export function buildCodexTaskPayload(
+  issue: GitHubIssue,
+  repository: GitHubRepository,
+  projectId?: string
+): CodexTaskPayload {
+  const labels = issue.labels?.map((label) => label.name).filter(Boolean) ?? []
+  const descriptionSections = [
+    issue.body?.trim() ? issue.body.trim() : DEFAULT_EMPTY_BODY_MESSAGE,
+    '',
+    '---',
+    '**Issue metadata**',
+    `- Repository: ${repository.full_name}`,
+    `- Issue #: ${issue.number}`,
+    `- Reported by: ${issue.user?.login ?? 'unknown'}`,
+    `- Labels: ${labels.length > 0 ? labels.join(', ') : 'none'}`,
+    `- URL: ${issue.html_url}`,
+  ]
+
+  const payload: CodexTaskPayload = {
+    title: `Fix GitHub issue #${issue.number}: ${issue.title}`,
+    description: descriptionSections.join('\n'),
+    metadata: {
+      source: 'github',
+      repository: repository.full_name,
+      issueNumber: issue.number,
+      issueUrl: issue.html_url,
+      labels,
+    },
+  }
+
+  if (projectId) {
+    payload.projectId = projectId
+  }
+
+  return payload
+}
+
+export async function createCodexTaskFromIssue(
+  issue: GitHubIssue,
+  repository: GitHubRepository
+): Promise<CodexTaskResponse> {
+  const { codexApiUrl, codexApiKey, codexProjectId } = env.server
+
+  if (!codexApiUrl) {
+    throw new Error('Codex API URL is not configured')
+  }
+
+  if (!codexApiKey) {
+    throw new Error('Codex API key is not configured')
+  }
+
+  const payload = buildCodexTaskPayload(issue, repository, codexProjectId ?? undefined)
+
+  const endpoint = `${normalizeCodexBaseUrl(codexApiUrl)}/tasks`
+
+  let response: Response
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${codexApiKey}`,
+      },
+      body: JSON.stringify(payload),
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    throw new Error(`Failed to reach Codex API: ${message}`)
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'Unable to read response body')
+    throw new Error(
+      `Codex API responded with ${response.status} ${response.statusText}: ${errorText}`
+    )
+  }
+
+  let data: unknown
+  try {
+    data = await response.json()
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    throw new Error(`Failed to parse Codex API response: ${message}`)
+  }
+
+  const result = data as Partial<CodexTaskResponse>
+  if (!result.id) {
+    throw new Error('Codex API response is missing a task identifier')
+  }
+
+  return {
+    id: result.id,
+    url: result.url,
+    status: result.status,
+  }
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -18,6 +18,10 @@ export const env = {
     nodeEnv: process.env.NODE_ENV || 'development',
     isDev: process.env.NODE_ENV === 'development',
     isProd: process.env.NODE_ENV === 'production',
+    githubWebhookSecret: process.env.GITHUB_WEBHOOK_SECRET,
+    codexApiUrl: process.env.CODEX_API_URL,
+    codexApiKey: process.env.CODEX_API_KEY,
+    codexProjectId: process.env.CODEX_PROJECT_ID,
   },
 } as const
 

--- a/test/lib/codex.test.ts
+++ b/test/lib/codex.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildCodexTaskPayload } from '@/lib/codex'
+import type { GitHubIssue, GitHubRepository } from '@/types/github'
+
+describe('buildCodexTaskPayload', () => {
+  const repository: GitHubRepository = {
+    id: 1,
+    name: 'newth-ai-next',
+    full_name: 'n3wth/newth-ai-next',
+    html_url: 'https://github.com/n3wth/newth-ai-next',
+  }
+
+  const issue: GitHubIssue = {
+    id: 42,
+    number: 128,
+    title: 'Fix navigation bug',
+    body: 'Steps to reproduce:\n1. Open navigation\n2. Click GitHub link',
+    html_url: 'https://github.com/n3wth/newth-ai-next/issues/128',
+    user: { login: 'octocat' },
+    labels: [{ name: 'bug' }, { name: 'high-priority' }],
+  }
+
+  it('creates a rich payload with metadata and description', () => {
+    const payload = buildCodexTaskPayload(issue, repository, 'project-123')
+
+    expect(payload.title).toBe('Fix GitHub issue #128: Fix navigation bug')
+    expect(payload.metadata.repository).toBe('n3wth/newth-ai-next')
+    expect(payload.metadata.issueNumber).toBe(128)
+    expect(payload.metadata.labels).toEqual(['bug', 'high-priority'])
+    expect(payload.projectId).toBe('project-123')
+    expect(payload.description).toContain('**Issue metadata**')
+    expect(payload.description).toContain('Repository: n3wth/newth-ai-next')
+    expect(payload.description).toContain('Issue #: 128')
+    expect(payload.description).toContain('Reported by: octocat')
+  })
+
+  it('uses a fallback when the issue body is empty', () => {
+    const payload = buildCodexTaskPayload({ ...issue, body: null, labels: [] }, repository)
+
+    expect(payload.description).toContain('No issue description provided')
+    expect(payload.metadata.labels).toEqual([])
+  })
+})

--- a/types/github.ts
+++ b/types/github.ts
@@ -1,0 +1,39 @@
+export interface GitHubUser {
+  id?: number
+  login: string
+  html_url?: string
+  avatar_url?: string
+}
+
+export interface GitHubLabel {
+  id?: number
+  name: string
+  color?: string
+}
+
+export interface GitHubIssue {
+  id?: number
+  number: number
+  title: string
+  body: string | null
+  html_url: string
+  user?: GitHubUser | null
+  labels?: GitHubLabel[]
+  state?: string
+  created_at?: string
+  updated_at?: string
+}
+
+export interface GitHubRepository {
+  id?: number
+  name: string
+  full_name: string
+  html_url: string
+}
+
+export interface GitHubIssueEvent {
+  action?: string
+  issue?: GitHubIssue
+  repository?: GitHubRepository
+  sender?: GitHubUser
+}

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,9 @@
     },
     "app/api/og/route.tsx": {
       "maxDuration": 10
+    },
+    "app/api/webhooks/github/route.ts": {
+      "maxDuration": 10
     }
   },
   "headers": [


### PR DESCRIPTION
## Summary
- add a GitHub issues webhook endpoint that verifies signatures and creates Codex tasks
- add Codex service helpers, GitHub typings, and a unit test for task payload generation
- document the required configuration and wire the webhook into the Vercel deployment settings

## Testing
- npm run lint
- npm run type-check
- npm run test:run

------
https://chatgpt.com/codex/tasks/task_e_68cda584b354832aabff6a6e5f42673b